### PR TITLE
Monkey patch the failed example notification.

### DIFF
--- a/lib/nodespec.rb
+++ b/lib/nodespec.rb
@@ -6,6 +6,7 @@ require 'nodespec/node_configurations'
 require 'nodespec/configuration_binding'
 require 'nodespec/run_options'
 require 'nodespec/provisioning'
+require 'nodespec/monkey_patch'
 
 module NodeSpec
   class << self

--- a/lib/nodespec/monkey_patch.rb
+++ b/lib/nodespec/monkey_patch.rb
@@ -1,0 +1,21 @@
+module RSpec::Core::Notifications
+  class FailedExampleNotification < ExampleNotification
+    def failure_lines
+      host = example.metadata[:nodespec]["host"]
+      @failure_lines ||=
+        begin
+          lines = []
+          lines << "On host `#{host}'" if host
+          lines << "Failure/Error: #{read_failed_line.strip}"
+          lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
+          exception.message.to_s.split("\n").each do |line|
+            lines << "  #{line}" if exception.message
+          end
+          lines << "  #{example.metadata[:command]}"
+          lines << "  #{example.metadata[:stdout]}" if example.metadata[:stdout]
+          lines << "  #{example.metadata[:stderr]}" if example.metadata[:stderr]
+          lines
+        end
+    end
+  end
+end


### PR DESCRIPTION
This is largely copied from serverspec, apart from the host being pulled from nodespec metadata.
